### PR TITLE
feat: 유저 인증용 Swagger BearerAuth 이름 설정

### DIFF
--- a/apps/api-server/src/post/post.controller.ts
+++ b/apps/api-server/src/post/post.controller.ts
@@ -11,15 +11,11 @@ import { GetPostsResponseDto } from './dto/get-posts-response.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ErrorResponse } from '../common/error-response';
 import { SearchPostsRequestDto } from './dto/search-posts-request.dto';
-import {
-  CurrencyType,
-  ProductCategory,
-  SortDirection,
-  TradeStatus,
-} from '../common/enums';
+import { CurrencyType, SortDirection, TradeStatus } from '../common/enums';
 
 @ApiTags('게시글')
-@ApiBearerAuth()
+@ApiBearerAuth('accessToken')
+@UseGuards(JwtAuthGuard)
 @Controller({
   path: 'posts',
   version: '1',
@@ -39,7 +35,6 @@ export class PostController {
     description: '잘못된 요청',
     type: ErrorResponse,
   })
-  @UseGuards(JwtAuthGuard)
   async getPosts(
     @Query() query: GetPostsRequestDto,
   ): Promise<GetPostsResponseDto> {

--- a/apps/api-server/src/university/university.controller.ts
+++ b/apps/api-server/src/university/university.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import {
   ApiOperation,
   ApiResponse,
@@ -8,10 +8,11 @@ import {
 import { UniversityService } from './university.service';
 import { SearchUniversitiesRequestDto } from './dto/search-universities-request.dto';
 import { SearchUniversitiesResponseDto } from './dto/search-universities-response.dto';
-import { ErrorResponse } from '../common/error-response';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('대학교')
-@ApiBearerAuth()
+@ApiBearerAuth('accessToken')
+@UseGuards(JwtAuthGuard)
 @Controller({
   path: 'universities',
   version: '1',

--- a/apps/api-server/src/user/user.controller.ts
+++ b/apps/api-server/src/user/user.controller.ts
@@ -34,7 +34,6 @@ import { CheckNicknameExistsDto } from './dto/check-nickname-exists.dto';
 import { CheckNicknameExistsResponseDto } from './dto/check-nickname-exists-response.dto';
 
 @ApiTags('유저')
-@ApiBearerAuth()
 @Controller({
   path: 'users',
   version: '1',
@@ -150,7 +149,7 @@ export class UserController {
     status: 401,
     description: '인증 실패',
   })
-  @ApiBearerAuth()
+  @ApiBearerAuth('accessToken')
   @UseGuards(JwtAuthGuard)
   @HttpCode(204)
   async saveInterestCities(
@@ -179,6 +178,7 @@ export class UserController {
     status: 401,
     description: '인증 실패',
   })
+  @ApiBearerAuth('accessToken')
   @UseGuards(JwtAuthGuard)
   async findInterestCities(
     @Req() req: Request,
@@ -211,6 +211,7 @@ export class UserController {
     status: 401,
     description: '인증 실패',
   })
+  @ApiBearerAuth('accessToken')
   @UseGuards(JwtAuthGuard)
   @HttpCode(204)
   async setPrimaryInterestCity(

--- a/libs/common/src/utils/swagger.ts
+++ b/libs/common/src/utils/swagger.ts
@@ -45,7 +45,7 @@ export function setupSwagger(
         description: 'JWT Authorization header using the Bearer scheme.',
         in: 'header',
       },
-      'access_token',
+      'accessToken',
     )
     .build();
 


### PR DESCRIPTION
## :pencil: 작업 내용

- Swagger UI 상 유저 인증용 BearerAuth 이름을 accessToken으로 지정
- 모듈별 controller level 및 method level로 Guard 바인딩

<br>

## :rotating_light: 핵심 로직

- 내용

<br>

## :white_check_mark: 배포 전 체크 리스트

- [ ] 테이블/스키마 변경
- [ ] package.json 버전 업
- [ ] 애플리케이션 버전 백업

<br>
