### PR TITLE
feat: 상품 게시글 리스트 조회 관련 컨트롤러용 dto에 필드 추가, 대학교 이메일 인증코드 발송 API 응답값 추가

### DIFF
--- a/apps/api-server/src/product-post/api/dto/find-my-likes.response.dto.ts
+++ b/apps/api-server/src/product-post/api/dto/find-my-likes.response.dto.ts
@@ -75,6 +75,12 @@ export class MyLikesItemDto {
   })
   tradeStatus: TradeStatus;
 
+  @ApiProperty({
+    description: '좋아요 여부 (내가 좋아요한 게시글인지)',
+    example: true,
+  })
+  isLiked: boolean;
+
   constructor(
     id: number,
     title: string,
@@ -87,6 +93,7 @@ export class MyLikesItemDto {
     chatRoomCount: number,
     regionId: string,
     tradeStatus: TradeStatus,
+    isLiked: boolean,
   ) {
     this.id = id;
     this.title = title;
@@ -99,6 +106,7 @@ export class MyLikesItemDto {
     this.chatRoomCount = chatRoomCount;
     this.regionId = regionId;
     this.tradeStatus = tradeStatus;
+    this.isLiked = isLiked;
   }
 }
 
@@ -138,6 +146,7 @@ export class FindMyLikesResponseDto {
             info.chatRoomCount,
             info.productPost.getRegionId(),
             info.productPost.getTradeStatus(),
+            info.isLiked,
           ),
       ),
       productPostInfoSlice.hasNext,

--- a/apps/api-server/src/product-post/api/dto/find-my-sales.response.dto.ts
+++ b/apps/api-server/src/product-post/api/dto/find-my-sales.response.dto.ts
@@ -81,6 +81,12 @@ export class MySalesItemDto {
   })
   isHidden: boolean;
 
+  @ApiProperty({
+    description: '좋아요 여부 (내가 좋아요한 게시글인지)',
+    example: false,
+  })
+  isLiked: boolean;
+
   constructor(
     id: number,
     title: string,
@@ -94,6 +100,7 @@ export class MySalesItemDto {
     regionId: string,
     tradeStatus: TradeStatus,
     isHidden: boolean,
+    isLiked: boolean,
   ) {
     this.id = id;
     this.title = title;
@@ -107,6 +114,7 @@ export class MySalesItemDto {
     this.regionId = regionId;
     this.tradeStatus = tradeStatus;
     this.isHidden = isHidden;
+    this.isLiked = isLiked;
   }
 }
 
@@ -147,6 +155,7 @@ export class FindMySalesResponseDto {
             info.productPost.getRegionId(),
             info.productPost.getTradeStatus(),
             info.productPost.getIsHidden(),
+            info.isLiked,
           ),
       ),
       productPostInfoSlice.hasNext,

--- a/apps/api-server/src/product-post/api/dto/find-user-sales.response.dto.ts
+++ b/apps/api-server/src/product-post/api/dto/find-user-sales.response.dto.ts
@@ -75,6 +75,12 @@ export class UserSalesItemDto {
   })
   tradeStatus: TradeStatus;
 
+  @ApiProperty({
+    description: '좋아요 여부 (내가 좋아요한 게시글인지)',
+    example: false,
+  })
+  isLiked: boolean;
+
   constructor(
     id: number,
     title: string,
@@ -87,6 +93,7 @@ export class UserSalesItemDto {
     chatRoomCount: number,
     regionId: string,
     tradeStatus: TradeStatus,
+    isLiked: boolean,
   ) {
     this.id = id;
     this.title = title;
@@ -99,6 +106,7 @@ export class UserSalesItemDto {
     this.chatRoomCount = chatRoomCount;
     this.regionId = regionId;
     this.tradeStatus = tradeStatus;
+    this.isLiked = isLiked;
   }
 }
 
@@ -138,6 +146,7 @@ export class FindUserSalesResponseDto {
             info.chatRoomCount,
             info.productPost.getRegionId(),
             info.productPost.getTradeStatus(),
+            info.isLiked,
           ),
       ),
       productPostInfoSlice.hasNext,

--- a/apps/api-server/src/university/api/dto/send-verification-code.response.dto.ts
+++ b/apps/api-server/src/university/api/dto/send-verification-code.response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SendVerificationCodeResponseDto {
+  @ApiProperty({
+    description: '인증코드 유효 기간 (초)',
+    example: 600,
+  })
+  expiresInSeconds: number;
+
+  static of(expiresInSeconds: number): SendVerificationCodeResponseDto {
+    const response = new SendVerificationCodeResponseDto();
+    response.expiresInSeconds = expiresInSeconds;
+    return response;
+  }
+}

--- a/apps/api-server/src/university/api/university.controller.ts
+++ b/apps/api-server/src/university/api/university.controller.ts
@@ -19,6 +19,7 @@ import { UniversityService } from '../application/university.service';
 import { SearchUniversitiesRequestDto } from './dto/search-universities.request.dto';
 import { SearchUniversitiesResponseDto } from './dto/search-universities.response.dto';
 import { SendVerificationCodeRequestDto } from './dto/send-verification-code.request.dto';
+import { SendVerificationCodeResponseDto } from './dto/send-verification-code.response.dto';
 
 @ApiTags('대학교')
 @ApiBearerAuth('accessToken')
@@ -52,15 +53,15 @@ export class UniversityController {
   }
 
   @Post('/email-verifications')
-  @HttpCode(204)
   @ApiOperation({
     summary: '대학교 이메일 인증코드 발송 API',
     description:
       '대학교 이메일로 6자리 인증코드를 발송합니다. 인증코드는 10분간 유효합니다.',
   })
   @ApiResponse({
-    status: 204,
+    status: 201,
     description: '인증코드 발송 성공',
+    type: SendVerificationCodeResponseDto,
   })
   @ApiResponse({
     status: 404,
@@ -69,10 +70,13 @@ export class UniversityController {
   async sendVerificationCode(
     @CurrentUser() userTokenInfo: UserTokenInfo,
     @Body() requestDto: SendVerificationCodeRequestDto,
-  ): Promise<void> {
-    await this.universityService.sendVerificationCode(
-      userTokenInfo.userId,
-      requestDto.email,
-    );
+  ): Promise<SendVerificationCodeResponseDto> {
+    const expiresInSeconds: number =
+      await this.universityService.sendVerificationCode(
+        userTokenInfo.userId,
+        requestDto.email,
+      );
+
+    return SendVerificationCodeResponseDto.of(expiresInSeconds);
   }
 }

--- a/apps/api-server/src/university/application/university.service.ts
+++ b/apps/api-server/src/university/application/university.service.ts
@@ -11,6 +11,8 @@ import { UniversityResultDto } from './dto/university.result.dto';
 
 @Injectable()
 export class UniversityService {
+  private readonly VERIFICATION_CODE_TTL = 600; // 10분 (600초)
+
   constructor(
     private readonly universityRepository: UniversityRepository,
     private readonly verificationCodeCacheRepository: VerificationCodeCacheRepository,
@@ -56,7 +58,7 @@ export class UniversityService {
     return Slice.of(pagedUniversities, hasNext);
   }
 
-  async sendVerificationCode(userId: number, email: string): Promise<void> {
+  async sendVerificationCode(userId: number, email: string): Promise<number> {
     // 1. 이메일에서 도메인 추출
     const domain: string = this.extractDomain(email);
 
@@ -82,6 +84,7 @@ export class UniversityService {
         email,
         universityId: university.id,
       }),
+      this.VERIFICATION_CODE_TTL,
     );
 
     // 5. SQS로 이메일 발송 요청
@@ -93,6 +96,9 @@ export class UniversityService {
         timestamp: new Date().toISOString(),
       },
     );
+
+    // 6. 인증코드 유효 기간 반환
+    return this.VERIFICATION_CODE_TTL;
   }
 
   private extractDomain(email: string): string {

--- a/libs/redis/src/repositories/verification-code-cache.repository.ts
+++ b/libs/redis/src/repositories/verification-code-cache.repository.ts
@@ -9,18 +9,13 @@ export class VerificationCodeCacheRepository {
 
   private readonly VERIFICATION_CODE_PREFIX = 'verification:code';
 
-  private readonly VERIFICATION_CODE_TTL = 600; // 10분 (600초)
-
   async setVerificationCode(
     userId: number,
     data: VerificationCodeCache,
+    ttl: number,
   ): Promise<void> {
     const key = buildRedisKey(this.VERIFICATION_CODE_PREFIX, userId.toString());
-    await this.redisClient.set(
-      key,
-      data.serialize(),
-      this.VERIFICATION_CODE_TTL,
-    );
+    await this.redisClient.set(key, data.serialize(), ttl);
   }
 
   async getVerificationCode(


### PR DESCRIPTION
## :pencil: 작업 내용

- 상품 게시글 리스트 조회 관련 컨트롤러용 dto에 필드 추가
  - 나의 판매내역 목록 조회 API", "내가 찜한 상품게시글 목록 조회 API", "다른 유저의 판매내역 목록 조회 API"의 컨트롤러용 dto에 좋아요 여부 필드 추가
- 대학교 이메일 인증코드 발송 API 응답값 추가
  - 인증코드 만료 시간(초)을 응답값으로 추가

<br>

## :rotating_light: 핵심 로직

- 내용

<br>

## :white_check_mark: 배포 전 체크 리스트

- [ ] 테이블/스키마 변경
- [ ] package.json 버전 업
- [ ] 애플리케이션 버전 백업

<br>
